### PR TITLE
fix(auth): remove localhost from production redirect URLs

### DIFF
--- a/AUTH_FIX_README.md
+++ b/AUTH_FIX_README.md
@@ -51,7 +51,7 @@ Changed the site URL and added production domains to redirect URLs:
 # in emails.
 site_url = "https://www.moscownpur.in"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000", "https://www.moscownpur.in", "https://moscownpur.in"]
+additional_redirect_urls = ["https://www.moscownpur.in", "https://moscownpur.in"]
 ```
 
 ## Important: Remote Supabase Configuration

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -114,7 +114,7 @@ enabled = true
 # in emails.
 site_url = "https://www.moscownpur.in"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000", "https://www.moscownpur.in", "https://moscownpur.in"]
+additional_redirect_urls = ["https://www.moscownpur.in", "https://moscownpur.in"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # Path to JWT signing key. DO NOT commit your signing keys file to git.


### PR DESCRIPTION
The localhost URL (127.0.0.1:3000) was accidentally included in production configuration files. This change removes it from both the README and config.toml to ensure only valid production domains are used for authentication redirects.